### PR TITLE
Replace 'sudo docker' with 'udocker'

### DIFF
--- a/cgatcore/pipeline.py
+++ b/cgatcore/pipeline.py
@@ -11,7 +11,7 @@ PARAMS = P.get_parameters("pipeline.yml")
 
 @originate('dependency_check.done')
 def dependency_check(outfile):
-    deps = ["wget", "unzip", "tar", "docker", "time"]
+    deps = ["wget", "unzip", "tar", "udocker", "time"]
     for cmd in deps:
         if shutil.which(cmd) is None:
             raise EnvironmentError("Required dependency \"{}\" not found".format(cmd))
@@ -47,7 +47,7 @@ def prepare_data(infile, outfile):
 @merge('AW*.xp1', 'calibration.log')
 def calibration(infiles, outfile):
     statement = '''\\time -o calibration.time -v
-    sudo docker run -v "$(pwd)":/data -t amigahub/casa:v1.0 --nogui --logfile calibration.log -c hcg-16-master/casa/calibration_flag.py
+    udocker run -v "$(pwd)":/data -t amigahub/casa:v1.0 --nogui --logfile calibration.log -c hcg-16-master/casa/calibration_flag.py
     1> calibration.stdout
     2> calibration.stderr'''
     P.run(statement)
@@ -55,7 +55,7 @@ def calibration(infiles, outfile):
 @transform(calibration, suffix('calibration.log'), 'imaging.log')
 def imaging(infile, outfile):
     statement = '''\\time -o imaging.time -v
-    sudo docker run -v "$(pwd)":/data -t amigahub/casa:v1.0 --nogui --logfile imaging.log -c hcg-16-master/casa/imaging.py
+    udocker run -v "$(pwd)":/data -t amigahub/casa:v1.0 --nogui --logfile imaging.log -c hcg-16-master/casa/imaging.py
     1> imaging.stdout
     2> imaging.stderr'''
     P.run(statement)
@@ -64,7 +64,7 @@ def imaging(infile, outfile):
 def masking(infile, outfiles):
     for mask in outfiles:
         statement = '''\\time -o masking.{}.time -v
-        sudo docker run -v "$(pwd)":/data -t amigahub/sofia:v1.0 hcg-16-master/sofia/{}.session
+        udocker run -v "$(pwd)":/data -t amigahub/sofia:v1.0 hcg-16-master/sofia/{}.session
         1> masking.{}.stdout
         2> masking.{}.stderr'''.format(mask, mask, mask, mask, mask)
         P.run(statement)

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,5 @@ dependencies:
  - matplotlib 3.0.*
  - nbconvert 5.5.*
  - numpy 1.16.*
+ - pip:
+   - git+https://github.com/indigo-dc/udocker@devel3

--- a/run.sh
+++ b/run.sh
@@ -123,11 +123,11 @@ if [[ -z "${UDOCKER_AVAIL}" ]] ; then
     BIN_DIR=$(dirname ${BIN_PYTHON})
     # get udocker release 1.1.4, which we know works
     curl -o ${BIN_DIR}/udocker https://raw.githubusercontent.com/indigo-dc/udocker/bcdb02c01480f32364481ab637201619405523d8/udocker.py
+    # configure run permissions
+    chmod +x ${BIN_DIR}/udocker
 else
     log " udocker is already installed."
 fi
-
-exit 0
 
 ### Download pipeline
 

--- a/run.sh
+++ b/run.sh
@@ -98,6 +98,25 @@ else
     conda activate hcg-16
 fi
 
+### udocker for python3 has not been released yet
+### https://github.com/indigo-dc/udocker/releases/tag/devel3_1.2.7
+### here are steps to install it
+
+UDOCKER_AVAIL=$(which udocker) || $(echo "")
+
+if [[ -z "${UDOCKER_AVAIL}" ]] ; then
+    log " udocker is not installed... installing it now"
+    # get /bin path for conda env
+    BIN_PYTHON=$(which python)
+    BIN_DIR=$(dirname ${BIN_PYTHON})
+    # get udocker release 1.1.4, which we know works
+    curl -o ${BIN_DIR}/udocker https://raw.githubusercontent.com/indigo-dc/udocker/bcdb02c01480f32364481ab637201619405523d8/udocker.py
+else
+    log " udocker is already installed."
+fi
+
+exit 0
+
 ### Download pipeline
 
 if [[ -r pipeline.py ]] ; then

--- a/run.sh
+++ b/run.sh
@@ -110,25 +110,6 @@ else
     conda activate hcg-16
 fi
 
-### udocker for python3 has not been released yet
-### https://github.com/indigo-dc/udocker/releases/tag/devel3_1.2.7
-### here are steps to install it
-
-UDOCKER_AVAIL=$(which udocker) || $(echo "")
-
-if [[ -z "${UDOCKER_AVAIL}" ]] ; then
-    log " udocker is not installed... installing it now"
-    # get /bin path for conda env
-    BIN_PYTHON=$(which python)
-    BIN_DIR=$(dirname ${BIN_PYTHON})
-    # get udocker release 1.1.4, which we know works
-    curl -o ${BIN_DIR}/udocker https://raw.githubusercontent.com/indigo-dc/udocker/bcdb02c01480f32364481ab637201619405523d8/udocker.py
-    # configure run permissions
-    chmod +x ${BIN_DIR}/udocker
-else
-    log " udocker is already installed."
-fi
-
 ### Download pipeline
 
 if [[ -r pipeline.py ]] ; then


### PR DESCRIPTION

Hi,

The changes proposed on this PR should help us get rid of the  `sudo docker` pre-requisite.

To try this out, please follow these steps:
```
# go to specific working dir
cd /path/to/working-dir

# get 'run.sh' from 'udocker' branch
curl -O https://raw.githubusercontent.com/AMIGA-IAA/hcg-16/udocker/run.sh

# replace all 'hcg-16/master' with 'hcg-16/udocker' in run.sh
sed -i 's/hcg-16\/master/hcg-16\/udocker/g' run.sh

# test it
bash run.sh
```

`udocker` downloads container images to `$HOME/.udocker` so it's important to check usage with:
```
du -sh $HOME/.udocker
du -sh working-dir
```

@jonesmg before merging, could you please run this branch on your end and let me know whether the output is exactly the same?

Best regards,
Sebastian