### PR TITLE
Deactivate inherited conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
  - python 3.6.*
  - aplpy 2.0.*
  - astropy 3.1.*
- - cgatcore 0.5.*
+ - cgatcore 0.5.12
  - jupyter
  - matplotlib 3.0.*
  - nbconvert 5.5.*

--- a/environment.yml
+++ b/environment.yml
@@ -12,5 +12,6 @@ dependencies:
  - matplotlib 3.0.*
  - nbconvert 5.5.*
  - numpy 1.16.*
+ - pip
  - pip:
    - git+https://github.com/indigo-dc/udocker@devel3

--- a/run.sh
+++ b/run.sh
@@ -104,7 +104,7 @@ else
         log " Conda already downloaded. "
     else
         log " Downloading conda... "
-        curl -o Miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86_64.sh >& /dev/null
+        curl -o Miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh >& /dev/null
     fi
     log " Install conda... "
     bash Miniconda.sh -b -p conda-install >& /dev/null

--- a/run.sh
+++ b/run.sh
@@ -57,7 +57,34 @@ function report_error() {
     exit 1
 }
 
-### Install/activate conda
+# function to deactivate inherited conda installation
+function deactivate_conda() {
+
+  PATH_LIST=$(echo $PATH | tr ':' ' ')
+  NEW_PATH=/usr/local/bin
+
+  for e in `echo $PATH_LIST`;
+  do
+    if [[ "$e" != *condabin ]] && [[ "$e" != "/usr/local/bin" ]] ; then
+      NEW_PATH=$NEW_PATH:$e
+    fi
+  done
+
+  echo $PATH
+  echo $NEW_PATH
+}
+
+### Deactivate inherited conda from existing environment
+
+EXISTS_CONDA=$(which conda) || $(echo "")
+
+if [[ "${EXISTS_CONDA}" ]] ; then
+    log " Install deactivate inherited conda... "
+    conda deactivate
+    deactivate_conda
+fi
+
+### Install/activate specific conda for this project
 
 # Check if pipeline has already installed conda
 if [[ -r conda-install/etc/profile.d/conda.sh ]] ; then


### PR DESCRIPTION

As raised in https://github.com/AMIGA-IAA/hcg-16/pull/8 users executing `run.sh` with a conda environment enabled will run into problems. These changes try to solve that issue by detecting and deactivating inherited conda installations.

Additionally we have made the following minor changes:
* after adding `mamba` for dependency resolution we can now use the latest version of Miniconda
* we will pin `cgatcore` to version 0.5.12 to avoid downloading additional dependencies to work with public clouds (not required for this project).
* mamba recommends adding `pip` to the list of dependencies since we use it to install `udocker`.
