### PR TITLE
Pin udocker to version 1.3.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,4 @@ dependencies:
  - curl
  - pip
  - pip:
-   - git+https://github.com/indigo-dc/udocker@devel3
+   - udocker==1.3.1


### PR DESCRIPTION
Hi,

I wanted to pin `udocker` before making a new release for Zenodo.

Here are the steps to give it a try before merging:
```
# go to specific working dir
cd /path/to/working-dir

# get 'run.sh' from 'udocker' branch
curl -O https://raw.githubusercontent.com/AMIGA-IAA/hcg-16/pin-udocker/run.sh

# replace all 'hcg-16/master' with 'hcg-16/pin-udocker' in run.sh
sed -i 's/hcg-16\/master/hcg-16\/pin-udocker/g' run.sh

# test it
bash run.sh
```
Please @jonesmg merge and make a release if you are happy with the results.

Many thanks,
Sebastian